### PR TITLE
Typo in composer.json, Fix #11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "hoa/consistency": "~1.0",
         "hoa/exception"  : "~1.0",
         "hoa/file"       : "~0.0",
-        "hoa/zformat"    : "~0.0"
+        "hoa/zformat"    : "~1.0"
     },
     "require-dev": {
         "hoa/test": "~2.0"


### PR DESCRIPTION
There's no 0.* tag on `Hoa\zformat`.